### PR TITLE
Add guarded ready/clientReady fallback and tests

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -29,4 +29,20 @@ for (const file of files) {
 if (!ok) fail('one or more command files are invalid');
 
 console.log('All command sanity checks passed.');
+// Additional unit tests for small utilities
+try {
+  const detectReadyEvent = require(path.join(__dirname, '..', 'src', 'detectReadyEvent'));
+  const assert = require('assert');
+
+  assert.strictEqual(detectReadyEvent('14.11.0'), 'ready');
+  assert.strictEqual(detectReadyEvent('15.0.0'), 'clientReady');
+  assert.strictEqual(detectReadyEvent('16.2.3'), 'clientReady');
+  assert.strictEqual(detectReadyEvent('not-a-version'), 'clientReady');
+
+  console.log('Utility tests passed.');
+} catch (e) {
+  console.error('Utility tests failed:', e);
+  process.exit(1);
+}
+
 process.exit(0);

--- a/src/detectReadyEvent.js
+++ b/src/detectReadyEvent.js
@@ -1,0 +1,24 @@
+// detectReadyEvent(installedVersion?) -> 'clientReady' | 'ready'
+// If `installedVersion` is provided, it's used; otherwise the function
+// attempts to read `discord.js/package.json` to obtain the installed
+// version. If version parsing fails, default to 'clientReady' to avoid
+// deprecation warnings on newer installations.
+function detectReadyEvent(installedVersion) {
+  let version = installedVersion;
+  if (!version) {
+    try {
+      const djPkg = require('discord.js/package.json');
+      version = djPkg && djPkg.version;
+    } catch (e) {
+      // If we can't read the package.json, prefer clientReady
+      return 'clientReady';
+    }
+  }
+
+  if (typeof version !== 'string') return 'clientReady';
+  const major = parseInt(version.split('.')[0], 10);
+  if (isNaN(major)) return 'clientReady';
+  return major >= 15 ? 'clientReady' : 'ready';
+}
+
+module.exports = detectReadyEvent;

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,23 @@ if (fs.existsSync(commandsPath)) {
 // Expose commands on client for command modules (help, etc.)
 client.commands = commands;
 
-client.once('ready', () => {
-  console.log(`Logged in as ${client.user?.tag || 'unknown'}`);
-});
+const detectReadyEvent = require('./detectReadyEvent');
+
+const _attachReadyEvent = () => {
+  const eventName = detectReadyEvent();
+  const onReady = () => {
+    console.log(`Logged in as ${client.user?.tag || 'unknown'}`);
+  };
+
+  if (eventName === 'ready') {
+    console.log('Falling back to legacy `ready` event for older discord.js');
+    client.once('ready', onReady);
+  } else {
+    client.once('clientReady', onReady);
+  }
+};
+
+_attachReadyEvent();
 
 // Handle slash commands (interactions)
 client.on('interactionCreate', async (interaction) => {


### PR DESCRIPTION
Adds a detectReadyEvent utility that selects the appropriate ready event (clientReady for discord.js >=15, ready for older versions). Index now uses the utility and logs when falling back. Includes unit assertions in scripts/run-tests.js.