### PR TITLE
Fix: remove obsolete docker-compose version attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-﻿version: '3.8'
-services:
+﻿services:
   verabot2:
     build: .
     env_file:


### PR DESCRIPTION
Removes the deprecated 'version' attribute from docker-compose.yml to eliminate the warning at startup. The version attribute is no longer necessary in docker-compose v2+.