### PR TITLE
fix: Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -247,6 +247,16 @@ function extractSection(markdown, sectionName) {
 // ========================================
 // Table of Contents Generation
 // ========================================
+// Safely escape text for inclusion in HTML.
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 function generateTableOfContents() {
     const content = document.getElementById('content');
     const tocNav = document.getElementById('tocNav');
@@ -264,7 +274,7 @@ function generateTableOfContents() {
         const level = parseInt(heading.tagName.substring(1));
         const text = heading.textContent;
         
-        return `<a href="#${id}" class="toc-level-${level}">${text}</a>`;
+        return `<a href="#${id}" class="toc-level-${level}">${escapeHtml(text)}</a>`;
     });
     
     tocNav.innerHTML = tocItems.join('');


### PR DESCRIPTION
Potential fix for [https://github.com/Rarsus/verabot2.0/security/code-scanning/1](https://github.com/Rarsus/verabot2.0/security/code-scanning/1)

In general, the problem is that we are taking DOM text (`heading.textContent`) and inserting it into an HTML string that is later written via `innerHTML`, without escaping meta-characters. To fix this, we must ensure that any untrusted text is either HTML-encoded before string interpolation or inserted into the DOM using text-safe APIs like `textContent`/`createTextNode`, and avoid constructing HTML strings with untrusted data.

The best targeted fix here is to escape the heading text before embedding it in the `<a>` tag HTML. We can do this by adding a small helper such as `escapeHtml(str)` that replaces `&`, `<`, `>`, `"`, and `'` with their HTML entities, and then wrapping `text` with this function when building the link string. This preserves existing functionality (still using `innerHTML` and link structure) but removes the XSS vector. Concretely in `website/app.js`, add an `escapeHtml` helper somewhere above `generateTableOfContents` (e.g., near other utility functions), and change the template literal in `generateTableOfContents` so that it uses `escapeHtml(text)` instead of `text`. No additional imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
