### PR TITLE
docs: fix broken discord.js link (ref #95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ module.exports = new MyCommand().register();
 
 ## 📚 Additional Resources
 
-- [Discord.js Documentation](https://discord.js.org/)
+- [Discord.js Documentation](https://discordjs.org/docs/packages/discord.js/main)
 - [Discord Developer Portal](https://discord.com/developers/applications)
 - [SQLite Documentation](https://www.sqlite.org/docs.html)
 


### PR DESCRIPTION
Hello! I found that the discord.js documentation link was outdated and causing issues. Updated it to the new format as suggested in issue #95.